### PR TITLE
feat: useQueryTrackのstaleTimeをInfinityにする #5

### DIFF
--- a/src/hooks/useQueryTrack.jsx
+++ b/src/hooks/useQueryTrack.jsx
@@ -14,7 +14,6 @@ export const useQueryTracks = (sortOption) => {
     queryKey: ["tracks", sortOption],
     queryFn: getTracks,
     staleTime: Infinity,
-    refetchInterval: 1000,
     onError: (err) => {
       if (err.response.data.message) {
         switchErrorHandling(err.response.data.message);


### PR DESCRIPTION
### Ticket
- issures番号
  -  #5

### What
- 実装内容
  - useQueryTrackのstaleTimeをInfinityにする

### Why
- 実装背景
  - ページの読み込みを速めるため

## Check
- [ ] 最終確認

